### PR TITLE
S max age

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,7 @@ fastify.listen(3000, (err) => {
 {
   privacy: 'value',
   expiresIn: 300,
+  serverExpiresIn: 2592000,
   cache: {get, set},
   cacheSegment: 'segment-name'
 }
@@ -106,7 +107,8 @@ fastify.listen(3000, (err) => {
 for a *cache-response-directive* as defined by RFC 2616.
 + `expiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the
 resource may be cached. When this is set, and `privacy` is not set to `no-cache`,
-then `', max-age=<value>'` will be appended to the `cache-control` header.
+then `', max-age=<value>'` will be appended to the `cache-control` header. (300 seconds = 5 minutes)
++ `serverExpiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the resource may be cached on the server. When this is set, and `privacy` is set to `public`,  then `', s-maxage=<value>'` will be appended to the `cache-control` header. (2,592,000 seconds = 30 days)
 + `cache` (Default: `abstract-cache.memclient`): an [abstract-cache][acache]
 protocol compliant cache object. Note: the plugin requires a cache instance to
 properly support the ETag mechanism. Therefore, if a falsy value is supplied

--- a/plugin.js
+++ b/plugin.js
@@ -70,7 +70,7 @@ function fastifyCachingPlugin (instance, options, next) {
       value = `${_options.privacy}, max-age=${_options.expiresIn}`
     }
 
-    if (_options.privacy.toLowerCase() == 'public' && _options.serverExpiresIn) {
+    if (_options.privacy.toLowerCase() === 'public' && _options.serverExpiresIn) {
       value += `, s-maxage=${_options.serverExpiresIn}`
     }
 

--- a/plugin.js
+++ b/plugin.js
@@ -71,7 +71,7 @@ function fastifyCachingPlugin (instance, options, next) {
     }
 
     if (_options.privacy.toLowerCase() == 'public' && _options.serverExpiresIn) {
-      value += `s-maxage=${_options.serverExpiresIn}`
+      value += `, s-maxage=${_options.serverExpiresIn}`
     }
 
     instance.addHook('onRequest', (req, res, next) => {

--- a/plugin.js
+++ b/plugin.js
@@ -8,6 +8,7 @@ const abstractCache = require('abstract-cache')
 
 const defaultOptions = {
   expiresIn: undefined,
+  serverExpiresIn: undefined,
   privacy: undefined,
   cache: undefined,
   cacheSegment: 'fastify-caching'
@@ -67,6 +68,10 @@ function fastifyCachingPlugin (instance, options, next) {
     let value = _options.privacy
     if (_options.privacy.toLowerCase() !== 'no-cache' && _options.expiresIn) {
       value = `${_options.privacy}, max-age=${_options.expiresIn}`
+    }
+
+    if (_options.privacy.toLowerCase() == 'public' && _options.serverExpiresIn) {
+      value += `s-maxage=${_options.serverExpiresIn}`
     }
 
     instance.addHook('onRequest', (req, res, next) => {


### PR DESCRIPTION
Allow use to have an s-maxage header as well as a max-age header so we can cache tiles longer in a CDN than we do in a browser